### PR TITLE
Don't alert on status, but display status payload.

### DIFF
--- a/check_freenas.py
+++ b/check_freenas.py
@@ -20,6 +20,7 @@ import argparse
 import json
 import sys
 import requests
+import re
 
 class FreenasAPI(object):
 
@@ -105,13 +106,14 @@ class FreenasAPI(object):
     def check_alerts(self):
         # Get alert status on the device
         alert_status = self._request('system/alert')
-        # Check the latest(?) alert and return the message
-        if alert_status[0]["level"] == "CRIT":
-            return (2, alert_status[0]["message"], None)
-        elif alert_status[0]["level"] == "WARN":
-            return (1, alert_status[0]["message"], None)
-        elif alert_status[0]["level"] == "OK":
-            return (0, alert_status[0]["message"], None)
+        # don't alert on status, sometimes messages stay resident
+        # and you have active checks on other system elements.
+        # instead, display last message payload from status API.
+        status_string = str(alert_status)
+        message = re.compile("message(.*)id")
+        print (message.search(status_string).group(1))
+        sys.exit (0)
+
 
 # Format results for Nagios processing
 def output_results(*exitstatus):


### PR DESCRIPTION
Since you already alert on key elements like volume or disk health,
alerting on status isn't needed.  This is also problematic as some
previous alerts (or the last status alert) is visible for quite some
time, even if it's just informational:

example: non actionable status alert.

(non fatal, informational)

': u'Pool pool0 state is ONLINE: One or more devices has experienced an unrecoverable error. An attempt was made to correct the error. Applications are unaffected.', u'

This PR does the following:

* Reverts alerting on API status
* Uses re to display only the "message" payload part of the raw/JSON API
status that's useful.

Here is what alert status looks like now with a failure:

![Screenshot_2019-11-16_02-03-53](https://user-images.githubusercontent.com/3940978/68993497-a4a72c00-0870-11ea-85bb-51239b9f5029.png)
Here is a normal alert status

![Screenshot_2019-11-16_01-59-20](https://user-images.githubusercontent.com/3940978/68993495-99540080-0870-11ea-98c6-d41f38842c40.png)

Related, I am using your script in my Nagios Ansible playbook here as
well, though I am templating it with jinja2 to allow SSL or non-SSL.

https://github.com/sadsfae/ansible-nagios/

